### PR TITLE
Add initial heroku support

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ django = "*"
 whitenoise = "*"
 "argon2-cffi" = "*"
 "psycopg2-binary" = "*"
+gunicorn = "*"
 
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a6012038944e3f5626444e30feb8609c27f439413613370e3936b943bcb77160"
+            "sha256": "743601e48e6a625766349dff28b7c0ee43b562e90d7584ddd7cf56928081d280"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -89,6 +89,13 @@
                 "sha256:d81a1652963c81488e709729a80b510394050e312f386037f26b54912a3a10d0"
             ],
             "version": "==2.0.4"
+        },
+        "gunicorn": {
+            "hashes": [
+                "sha256:75af03c99389535f218cc596c7de74df4763803f7b63eb09d77e92b3956b36c6",
+                "sha256:eee1169f0ca667be05db3351a0960765620dad53f53434262ff8901b68a1b622"
+            ],
+            "version": "==19.7.1"
         },
         "psycopg2-binary": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ See [CONTRIBUTING](CONTRIBUTING.md) for additional information.
 Developer documentation is located wthin in the [docs](docs/) directory.
 To get started, see the [local development guide](docs/local-development.md).
 
+## Deploying
+
+The staging, and production instances of the USKPA website are deployed
+using Heroku, additional documentation is located in [deploy.md](docs/deploy.md).
+
 ## Public domain
 
 This project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](CONTRIBUTING.md):

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+# USKPA Developer documentation
+
+Welcome to the USKPA website documentation. This documentation is written in
+[GitHub-flavored markdown][gh-md] and is best read using the GitHub interface.
+
+## Table of Contents
+
+- [Getting Started with Local Development](local-development.md)
+- [Deployment Process](deploy.md)
+
+[gh-md]: https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,51 @@
+## Deploying the USKPA Website
+[:arrow_left: Back to USKPA
+Documentation](../docs)
+
+Two instances of the USKPA website are hosted by [Heroku].
+
+* Staging - https://uskpa-staging.herokuapp.com/
+* Production - https://uskpa.herokuapp.com/
+
+### Heroku
+
+At this early stage we're using the [Heroku CLI]
+to manage all user-facing instances of the application. In the future we
+will transition to automated deployments via continuous integration.
+
+Please see the Heroku CLI docs on [deploying with git](https://devcenter.heroku.com/articles/git).
+
+**Note:** Interacting with the specific Heroku Applications
+dicussed below is limited to those with the necessary permissions.
+
+### Staging
+*Heroku app: uskpa-staging*
+
+Deployed from: [master](https://github.com/18F/uskpa/tree/master)
+
+The staging environment exists to test new releases prior
+to their production deployment.
+
+The staging database and application are indepedent of
+and share no data with the production instance.
+
+Example using the [Heroku CLI]:
+
+```shell
+$ heroku login
+$ heroku git:remote -a uskpa-staging
+$ git push heroku master
+
+# If migrations are required
+$ heroku run python manage.py migrate
+```
+
+### Production
+*Heroku app: uskpa*
+
+Deployed from: Tagged release
+
+Future host of the production USKPA website.
+
+[Heroku]: https://heroku.com
+[Heroku CLI]: https://devcenter.heroku.com/articles/heroku-cli

--- a/uskpa/settings.py
+++ b/uskpa/settings.py
@@ -27,7 +27,7 @@ SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', '!!NOT-A-SECRET!!')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['.herokuapp.com']
 
 
 # Application definition


### PR DESCRIPTION
Making project deployable to Heroku per #1.

This includes a minimal setup which is driven manually via the Heroku CLI tool. 