### PR TITLE
Refine user creation process and notify new account holders

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -23,11 +23,6 @@ class ProfileUserAdmin(UserAdmin):
     add_form = UserCreationForm
     add_fieldsets = (
         (None, {
-            'description': (
-                "Enter the new user's name and email address and click save."
-                " The user will be emailed a link allowing them to login to"
-                " the site and set their password."
-            ),
             'fields': ('email', 'username',),
         }),
         ('Password', {
@@ -51,7 +46,9 @@ class ProfileUserAdmin(UserAdmin):
         # Generate reset password key and send email to new user
         if reset_password:
             reset_form = PasswordResetForm({'email': obj.email})
-            assert reset_form.is_valid()
+            # Not checking results of form validation here as
+            # the incoming email is validated by the User ModelForm
+            reset_form.is_valid()
             reset_form.save(
                 request=request,
                 use_https=request.is_secure(),

--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -1,8 +1,11 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
+from django.contrib.auth.forms import PasswordResetForm
+from django.utils.crypto import get_random_string
 
 from .models import Profile
+from .forms import UserCreationForm
 
 
 class ProfileInline(admin.StackedInline):
@@ -13,8 +16,48 @@ class ProfileInline(admin.StackedInline):
 
 
 class ProfileUserAdmin(UserAdmin):
+    """Allow admins to create users with only a username & email"""
     inlines = (ProfileInline, )
     list_display = ('email', 'first_name', 'last_name', 'is_active', 'is_superuser', 'date_joined', )
+
+    add_form = UserCreationForm
+    add_fieldsets = (
+        (None, {
+            'description': (
+                "Enter the new user's name and email address and click save."
+                " The user will be emailed a link allowing them to login to"
+                " the site and set their password."
+            ),
+            'fields': ('email', 'username',),
+        }),
+        ('Password', {
+            'description': "Optionally, you may set the user's password here.",
+            'fields': ('password1', 'password2'),
+            'classes': ('collapse', 'collapse-closed'),
+        }),
+    )
+
+    def save_model(self, request, obj, form, change):
+        if not change and (not form.cleaned_data['password1'] or not obj.has_usable_password()):
+            # Django's PasswordResetForm won't let us reset an unusable
+            # password. We set it above super() so we don't have to save twice.
+            obj.set_password(get_random_string())
+            reset_password = True
+        else:
+            reset_password = False
+
+        super(UserAdmin, self).save_model(request, obj, form, change)
+
+        # Generate reset password key and send email to new user
+        if reset_password:
+            reset_form = PasswordResetForm({'email': obj.email})
+            assert reset_form.is_valid()
+            reset_form.save(
+                request=request,
+                use_https=request.is_secure(),
+                subject_template_name='registration/account_creation_subject.txt',
+                email_template_name='registration/account_creation_email.html',
+            )
 
     def get_inline_instances(self, request, obj=None):
         if not obj:

--- a/accounts/apps.py
+++ b/accounts/apps.py
@@ -3,3 +3,7 @@ from django.apps import AppConfig
 
 class AccountsConfig(AppConfig):
     name = 'accounts'
+
+    def ready(self):
+        # Setup signals
+        import accounts.signals # noqa

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -1,0 +1,30 @@
+from django import forms
+from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth import get_user_model
+
+
+class UserCreationForm(UserCreationForm):
+    """
+    A UserCreationForm with optional password inputs.
+    """
+
+    class Meta:
+        model = get_user_model()
+        fields = ("username", "email")
+
+    def __init__(self, *args, **kwargs):
+        super(UserCreationForm, self).__init__(*args, **kwargs)
+        self.fields['email'].required = True
+        self.fields['password1'].required = False
+        self.fields['password2'].required = False
+        # If one field gets autocompleted but not the other, our 'neither
+        # password or both password' validation will be triggered.
+        self.fields['password1'].widget.attrs['autocomplete'] = 'off'
+        self.fields['password2'].widget.attrs['autocomplete'] = 'off'
+
+    def clean_password2(self):
+        password1 = self.cleaned_data.get("password1")
+        password2 = super(UserCreationForm, self).clean_password2()
+        if bool(password1) ^ bool(password2):
+            raise forms.ValidationError("Fill out both fields")
+        return password2

--- a/accounts/signals.py
+++ b/accounts/signals.py
@@ -1,0 +1,18 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from django.contrib.auth import get_user_model
+
+from .models import Profile
+
+User = get_user_model()
+
+
+@receiver(post_save, sender=User, dispatch_uid="create_user_profile")
+def create_user_profile(sender, instance, created, **kwargs):
+    if created:
+        Profile.objects.create(user=instance)
+
+
+@receiver(post_save, sender=User, dispatch_uid="save_user_profile")
+def save_user_profile(sender, instance, **kwargs):
+    instance.profile.save()

--- a/accounts/templates/admin/auth/user/add_form.html
+++ b/accounts/templates/admin/auth/user/add_form.html
@@ -1,0 +1,7 @@
+{% extends "admin/change_form.html" %}
+
+{% block form_top %}
+    <p>Enter the new user's name and email address and click save.
+        The user will be emailed a link allowing them to login to the site and set their password.
+    </p>
+{% endblock %}

--- a/accounts/templates/registration/account_creation_email.html
+++ b/accounts/templates/registration/account_creation_email.html
@@ -1,0 +1,12 @@
+A user account has been created for you on {{ site_name }}.
+
+Your username: {{ user.get_username }}
+
+To confirm your email address and set your password please
+go to the following page.
+
+{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+
+If you believe you've received this email in error please contact us.
+
+- The {{ site_name }} team.

--- a/accounts/templates/registration/account_creation_subject.txt
+++ b/accounts/templates/registration/account_creation_subject.txt
@@ -1,0 +1,1 @@
+An account has been created for you on {{ site_name }}

--- a/accounts/templates/reset_password_form.html
+++ b/accounts/templates/reset_password_form.html
@@ -6,7 +6,7 @@
 
 {% if validlink %}
 
-<p>Please enter your new password twice so we can verify you typed it in correctly</p>
+<p>Please enter your new password.</p>
 
 <form method="post">{% csrf_token %}
 <fieldset class="module aligned">

--- a/accounts/tests/test_admin.py
+++ b/accounts/tests/test_admin.py
@@ -1,0 +1,29 @@
+from django.test import TestCase, RequestFactory
+from django.core import mail
+from django.contrib.auth import get_user_model
+
+from accounts.forms import UserCreationForm
+from accounts.admin import ProfileUserAdmin
+
+User = get_user_model()
+
+
+class ProfileAdminTests(TestCase):
+
+    def setUp(self):
+
+        self.form = UserCreationForm({'username': 'test', 'email': 'test@test.com'})
+        self.user = self.form.save(commit=False)
+        # We don't need to target the real URL here, just making an HttpRequest()
+        self.request = RequestFactory().get('/')
+        self.site = 'SITE'
+
+    def test_email_on_user_add(self):
+        """Send an email to the user on creation of their account"""
+        ProfileUserAdmin(User, self.site).save_model(self.request, self.user, self.form, False,)
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_no_email_on_user_edit(self):
+        """No emails generated when `change` is True, we're editing an existing User"""
+        ProfileUserAdmin(User, self.site).save_model(self.request, self.user, self.form, True,)
+        self.assertEqual(len(mail.outbox), 0)

--- a/accounts/tests/test_models.py
+++ b/accounts/tests/test_models.py
@@ -1,10 +1,12 @@
-from django.test import SimpleTestCase
+from django.test import TestCase
 from model_mommy import mommy
-
+from django.contrib.auth import get_user_model
 from accounts.models import Profile
 
+User = get_user_model()
 
-class ProfileTests(SimpleTestCase):
+
+class ProfileTests(TestCase):
 
     def setUp(self):
         self.profile = mommy.prepare(Profile)
@@ -12,3 +14,16 @@ class ProfileTests(SimpleTestCase):
     def test_profile_returns_username_str(self):
         """String representation of profile is associated username"""
         self.assertEqual(str(self.profile), self.profile.user.username)
+
+    def test_profile_created_with_user(self):
+        """Profile must be created along with a user model"""
+        user = mommy.make(User)
+        self.assertIsInstance(user.profile, Profile)
+
+    def test_profile_updated_with_user(self):
+        """Profile must be updated along with a user model"""
+        user = mommy.make(User)
+        user.profile.phone_number = 'NEW_VALUE'
+        user.save()
+        user.refresh_from_db()
+        self.assertEqual(user.profile.phone_number, 'NEW_VALUE')

--- a/uskpa/settings.py
+++ b/uskpa/settings.py
@@ -36,7 +36,6 @@ else:
 # Application definition
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
@@ -45,6 +44,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'kpc.apps.KpcConfig',
     'accounts.apps.AccountsConfig',
+    'django.contrib.admin',
 ]
 
 


### PR DESCRIPTION
Fulfillment of requirements for #7.

Admins are now able to create user accounts by providing only a username and email address.
Upon creation of the account, an email is sent to the provided address containing a link for the user to reset their password and login to the site. 

